### PR TITLE
Fix for issue #38

### DIFF
--- a/Peerbox/bin/peerbox
+++ b/Peerbox/bin/peerbox
@@ -387,12 +387,19 @@ if args.stop:
         print("Peerbox is not running.")
 
 if args.autostart:
-    if args.autostart[0].lower() == "tor":
-        sh.sudo("systemctl", "enable", "ppcoind-tor@{0}.service".format(getpass.getuser()))
-        print("Peerbox Tor will now autostart at boot time.")
+    if args.autostart[0]:
+        if args.autostart[0].lower() == "tor":
+            sh.sudo("systemctl", "enable", "ppcoind-tor@{0}.service".format(getpass.getuser()))
+            print("Peerbox Tor will now autostart at boot time.")
+            print("Disable autostart with\n  peerbox -noautostart no")
+        elif args.autostart[0].lower() == "no":
+            sh.sudo("systemctl", "disable", "ppcoind-tor@{0}.service".format(getpass.getuser()))
+                sh.sudo("systemctl", "disable", "ppcoind@{0}.service".format(getpass.getuser()))
+            print("Peerbox autostart at boot time is now disabled.")
     else:
         sh.sudo("systemctl", "enable", "ppcoind@{0}.service".format(getpass.getuser()))
         print("Peerbox will now autostart at boot time.")
+        print("Disable autostart with\n  peerbox -autostart no")
 
 if args.onion:
     try:

--- a/Peerbox/bin/peerbox
+++ b/Peerbox/bin/peerbox
@@ -394,7 +394,7 @@ if args.autostart:
             print("Disable autostart with\n  peerbox -noautostart no")
         elif args.autostart[0].lower() == "no":
             sh.sudo("systemctl", "disable", "ppcoind-tor@{0}.service".format(getpass.getuser()))
-                sh.sudo("systemctl", "disable", "ppcoind@{0}.service".format(getpass.getuser()))
+            sh.sudo("systemctl", "disable", "ppcoind@{0}.service".format(getpass.getuser()))
             print("Peerbox autostart at boot time is now disabled.")
     else:
         sh.sudo("systemctl", "enable", "ppcoind@{0}.service".format(getpass.getuser()))


### PR DESCRIPTION
Checking additional argument for NoneType (because NoneType does not have method `lower()`.

When started only with option `-autostart` the following error arose:

    Traceback (most recent call last):
    File "/usr/bin/peerbox", line 376, in <module>
    if args.autostart[0].lower() == "tor":
    AttributeError: 'NoneType' object has no attribute

My pull request fixes #38 and adds info about disabling autostart via additional argument `no`.
