### PR TITLE
syntax error in postinstall script

### DIFF
--- a/Peerbox/bin/peerbox
+++ b/Peerbox/bin/peerbox
@@ -322,7 +322,7 @@ if __name__ == "__main__":
     parser.add_argument("-rates", help="current average PPC exchange rates in USD and BTC", action="store_true")
     parser.add_argument("-start", help="start Peerbox", action="store_true")
     parser.add_argument("-stop", help="stop Peerbox", action="store_true")
-    parser.add_argument("-autostart", help="make Peerbox autostart at boot time", nargs='?', action='append')
+    parser.add_argument("-autostart", help="make Peerbox autostart at boot time; with argument »tor« means autostart Peerbox with Tor; with argument »no« means disalbe autostart", nargs='?', action='append')
     parser.add_argument("-tor", help="start Peerbox with Tor", action="store_true")
     parser.add_argument("-onion", help="show .onion address if node has one", action="store_true")
     parser.add_argument("-restart", help="restart Peerbox", action="store_true")

--- a/Peerbox/debian/postinst
+++ b/Peerbox/debian/postinst
@@ -13,7 +13,7 @@ intro() {
 	|_|   \___|\___|_|  |_.__/ \___/_/\_\ "
 
 	echo "
-	  version: 0.6.4
+	  version: 0.6.5
 	  url: www.peerbox.me
 	  forum: https://www.peercointalk.org/index.php?board=68.0
 	  git: https://github.com/peerchemist/Peerbox
@@ -43,7 +43,7 @@ conf() {
 }
 
 rename() {
-	if "$HOSTNAME" != "peerbox"; then
+	if [ "$HOSTNAME" != "peerbox" ]; then
 
 			echo "
 	Do you want to rename this machine to 'peerbox'?

--- a/Peerbox/setup.py
+++ b/Peerbox/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup
 
 setup(name='peerbox',
-      version='0.6.4',
+      version='0.6.5',
       description='Peerbox control scripts',
       url='https://github.com/peerchemist/Peerbox',
       author='Peerchemist',
       author_email='peerchemist@protonmail.ch',
-      license='GLP',
+      license='GPL',
       scripts=['bin/peerbox'],
       zip_safe=False)


### PR DESCRIPTION
Most important was the syntax error in the postinstall script, which lead to an abortion of the script when checking for the hostname. The other stuff is only makeover.

        changed:       Peerbox/bin/peerbox         improved help text
        changed:       Peerbox/debian/postinst     syntax error and
        version bumb
        changed:       Peerbox/setup.py            typo and version
        bump